### PR TITLE
Bump hibernate-validator from 5.3.5.Final to 6.0.23.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>5.3.5.Final</version>
+			<version>6.0.23.Final</version>
 		</dependency>
 		<!-- TEST UNIT -->
 	<!--	<dependency>


### PR DESCRIPTION
Bumps hibernate-validator from 5.3.5.Final to 6.0.23.Final.

---
updated-dependencies:
- dependency-name: org.hibernate:hibernate-validator
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>